### PR TITLE
Use quotes for directories when using shell commands

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -466,7 +466,7 @@ const PREPARE = () => {
     log(chalk.blue(`Processing ${babelTarget}`));
     log(chalk.blue(`npx ${babelBin} "${babelTarget}" -d "${babelTarget}" --config-file "${babelConfig}"`));
 
-    //shell.exec(`node ${babelBin} ${babelTarget} -d ${babelTarget} --config-file ${babelConfig}`);
+    //shell.exec(`node ${babelBin} "${babelTarget}" -d "${babelTarget}" --config-file "${babelConfig}"`);
     shell.exec(`npx ${babelBin} "${babelTarget}" -d "${babelTarget}" --config-file "${babelConfig}"`);
 };
 

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -464,10 +464,10 @@ const PREPARE = () => {
 
 
     log(chalk.blue(`Processing ${babelTarget}`));
-    log(chalk.blue(`npx ${babelBin} ${babelTarget} -d ${babelTarget} --config-file ${babelConfig}`));
+    log(chalk.blue(`npx ${babelBin} "${babelTarget}" -d "${babelTarget}" --config-file "${babelConfig}"`));
 
     //shell.exec(`node ${babelBin} ${babelTarget} -d ${babelTarget} --config-file ${babelConfig}`);
-    shell.exec(`npx ${babelBin} ${babelTarget} -d ${babelTarget} --config-file ${babelConfig}`);
+    shell.exec(`npx ${babelBin} "${babelTarget}" -d "${babelTarget}" --config-file "${babelConfig}"`);
 };
 
 


### PR DESCRIPTION
Fixes error when a directory has spaces